### PR TITLE
Implement blueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/apiary.apib
+/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+HERCULE := ./node_modules/.bin/hercule
+DREDD := ./node_modules/.bin/dredd
+SOURCES := apiary.apib sample.apib \
+	sample.refract.parse-result.json \
+	sample.refract.parse-result.yaml \
+	sample.apiblueprint.parse-result.json \
+	sample.apiblueprint.parse-result.yaml \
+	sample.apiblueprint.ast-2.0.yaml \
+	sample.apiblueprint.ast-2.0.json
+DEPENDENCIES = $(foreach file,$(SOURCES),source/$(file))
+HOST := https://api.apiblueprint.org/
+
+apiary.apib: node_modules $(DEPENDENCIES)
+	@echo "Transcluding API Blueprint"
+	@$(HERCULE) source/apiary.apib -o apiary.apib
+
+test: node_modules apiary.apib
+	$(DREDD) --hookfiles source/dredd-hooks.js apiary.apib $(HOST)
+
+clean:
+	@echo "Cleaning"
+	@rm -fr apiary.apib
+
+publish: apiary.apib
+	@echo "Uploading blueprint to Apiary"
+	@apiary publish --api-name=apiblueprint
+
+node_modules:
+	npm install hercule dredd npm js-yaml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# api.apiblueprint.org
+# API Blueprint API
+
+[![Apiary Documentation](https://img.shields.io/badge/Apiary-Documented-blue.svg)](http://docs.apiblueprint.apiary.io/)
+
+This repository contains the API Blueprint for the API Blueprint parsing service.
+You can find the documentation for the parsing service on
+[Apiary](http://docs.apiblueprint.apiary.io/).
+
+## Usage
+
+The API Blueprint uses [hercule](https://github.com/jamesramsay/hercule) to
+transclude multiple files into the blueprint. To build the blueprint you
+will need to install Node, then you can run the following to build the
+`apiary.apib` blueprint:
+
+```shell
+$ make
+Transcluding API Blueprint
+```

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+machine:
+  ruby:
+    version: 2.2.3
+  node:
+    version: v0.12.7
+
+dependencies:
+  override:
+    - gem install apiaryio
+
+test:
+  override:
+    - make
+
+deployment:
+  production:
+    branch: master
+    commands:
+      - make publish

--- a/source/apiary.apib
+++ b/source/apiary.apib
@@ -1,0 +1,205 @@
+FORMAT: 1A
+HOST: https://api.apiblueprint.org
+
+# API Blueprint API
+API Blueprint parsing service provides parsing of API Blueprint "as a service".
+
+## Media Types
+The API uses [content negotiation](https://en.wikipedia.org/wiki/Content_negotiation) heavily. Send requests with the `Content-Type` header set to the right input media type and use the `Accept` header to select desired output as a response.
+
+![Media Types](https://github.com/apiaryio/plutonium/blob/master/assets/mediatypes.svg?raw=true)
+
+### Resource State Representation
+
+```
+application/hal+json
+```
+
+Where applicable this API uses the [HAL+JSON](https://github.com/mikekelly/hal_specification/blob/master/hal_specification.md) media type to represent resource states and to provide available affordances.
+
+### Error States
+The common [HTTP Response Status Codes](https://github.com/for-GET/know-your-http-well/blob/master/status-codes.md) are used. Error responses use the [vnd.error](https://github.com/blongden/vnd.error) media type.
+
+## Service Root [/]
+API entry point.
+
+This resource does not have any attributes, instead it provides list of available affordances.
+
+### Affordances
+- `parse` - Parse an API description
+
+    See _API Description Parser_ resource's _Parser_ action for details.
+
+- `compose` - Composes an API description
+
+    See _API Description Composer_ resource's _Compose_ action for details.
+
+### List [GET]
+
++ Relation: index
+
++ Response 200 (application/hal+json)
+    + Headers
+
+            Link: <http://docs.apiblueprint.apiary.io>; rel="profile"
+
+    + Body
+
+            {
+                "_links": {
+                    "self": {"href": "/"},
+                    "parse": {"href": "/parser"},
+                    "compose": {"href": "/composer"}
+                }
+            }
+
+## API Description Parser [/parser]
+Parse an API description format.
+
+### Parse [POST]
+API Blueprint parsing is performed as it is provided by the [Drafter](https://github.com/apiaryio/drafter) reference parser.
+
+#### Input Media Types
+
+##### API Blueprint
+
+```
+text/vnd.apiblueprint
+```
+
+API Blueprint as defined in its [specification](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md).
+
+#### Output Media Types
+
+##### API Description Parse Result Namespace
+
+```
+application/vnd.refract.parse-result+json
+application/vnd.refract.parse-result+yaml
+```
+
+General-purpose result of the parsing operation. The parse result is in form of the Refract data structure as defined in its [specification](https://github.com/refractproject/refract-spec). The parse result data comply with the [Parse Result Namespace](https://github.com/refractproject/refract-spec/blob/master/namespaces/parse-result.md).
+
+##### API Blueprint Parse Result
+
+```
+application/vnd.apiblueprint.parseresult+json
+application/vnd.apiblueprint.parseresult+yaml
+```
+
+API Blueprint Parse Result is just serialized API Blueprint AST (`application/vnd.apiblueprint.ast+json` or `application/vnd.apiblueprint.ast+yaml`) alongside with parser annotations (source map, warnings and errors) defined in [Parse Result Media Types](https://github.com/apiaryio/api-blueprint-ast/blob/master/Parse%20Result.md).
+
+Please keep in mind that the API Blueprint parse result media types are soon to be deprecated in favor of the API Description Parse Result Namespace.
+
++ Relation: parse
+
++ Request Parse API Blueprint into Parse Result Namespace as JSON (text/vnd.apiblueprint)
+
+    + Headers
+
+            Accept: application/vnd.refract.parse-result+json
+
+    + Body
+
+            :[](sample.apib)
+
++ Response 200 (application/vnd.refract.parse-result+json)
+
+        :[](sample.refract.parse-result.json)
+
++ Request Parse API Blueprint into Parse Result Namespace as YAML (text/vnd.apiblueprint)
+
+    + Headers
+
+            Accept: application/vnd.refract.parse-result+yaml
+
+    + Body
+
+            :[](sample.apib)
+
++ Response 200 (application/vnd.refract.parse-result+yaml)
+
+        :[](sample.refract.parse-result.yaml)
+
++ Request Parse API Blueprint into JSON Parse Result AST (text/vnd.apiblueprint)
+
+    + Headers
+
+            Accept: application/vnd.apiblueprint.parseresult+json; version=2.2
+
+    + Body
+
+            :[](sample.apib)
+
++ Response 200 (application/vnd.apiblueprint.parseresult+json; version=2.2)
+
+        :[](sample.apiblueprint.parse-result.json)
+
++ Request Parse API Blueprint into YAML Parse Result AST (text/vnd.apiblueprint)
+
+    + Headers
+
+            Accept: application/vnd.apiblueprint.parseresult+yaml; version=2.2
+
+    + Body
+
+            :[](sample.apib)
+
++ Response 200 (application/vnd.apiblueprint.parseresult+yaml; version=2.2)
+
+        :[](sample.apiblueprint.parse-result.yaml)
+
+## API Description Composer [/composer]
+Reverse the parsing process--compose an API description format.
+
+### Compose [POST]
+The composition of API Blueprint is performed as it is provided by the [Matter Compiler](https://github.com/apiaryio/matter_compiler) tool.
+
+#### Input Media Types
+
+##### API Blueprint AST
+
+```
+application/vnd.apiblueprint.ast+json
+application/vnd.apiblueprint.ast+yaml
+```
+
+Serialized API Blueprint AST represented either in its JSON or YAML format as defined in [API Blueprint AST Serialization Media Types](https://github.com/apiaryio/api-blueprint-ast).
+
+Please keep in mind that the API Blueprint AST is soon to be deprecated in favor of the API Description Parse Result Namespace.
+
+#### Output Media Types
+
+##### API Blueprint
+
+```
+text/vnd.apiblueprint
+```
+
+API Blueprint as defined in its [specification](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md).
+
++ Relation: compose
+
++ Request Compose API Blueprint from AST 2.0 sent as YAML (application/vnd.apiblueprint.ast+yaml; version=2.0)
+
+        :[](sample.apiblueprint.ast-2.0.yaml)
+
++ Response 200 (text/vnd.apiblueprint)
+
+        ## /message
+        ### GET
+        + Response 200 (text/plain)
+
+                Hello World!
+
++ Request Compose API Blueprint from AST 2.0 sent as JSON (application/vnd.apiblueprint.ast+json; version=2.0)
+
+        :[](sample.apiblueprint.ast-2.0.json)
+
++ Response 200 (text/vnd.apiblueprint)
+
+        ## /message
+        ### GET
+        + Response 200 (text/plain)
+
+                Hello World!

--- a/source/apiary.apib
+++ b/source/apiary.apib
@@ -186,11 +186,7 @@ API Blueprint as defined in its [specification](https://github.com/apiaryio/api-
 
 + Response 200 (text/vnd.apiblueprint)
 
-        ## /message
-        ### GET
-        + Response 200 (text/plain)
-
-                Hello World!
+        :[](sample.apib)
 
 + Request Compose API Blueprint from AST 2.0 sent as JSON (application/vnd.apiblueprint.ast+json; version=2.0)
 
@@ -198,8 +194,4 @@ API Blueprint as defined in its [specification](https://github.com/apiaryio/api-
 
 + Response 200 (text/vnd.apiblueprint)
 
-        ## /message
-        ### GET
-        + Response 200 (text/plain)
-
-                Hello World!
+        :[](sample.apib)

--- a/source/dredd-hooks.js
+++ b/source/dredd-hooks.js
@@ -1,0 +1,18 @@
+var hooks = require('hooks');
+var yaml = require('js-yaml');
+
+hooks.beforeEachValidation(function (transaction) {
+  // Sort YAML so the ordering is identical for Dredd comparisons
+  if (transaction.expected.headers['Content-Type'].match(/.*yaml.*/)) {
+    var requestBody = yaml.safeLoad(transaction.expected.body);
+    var responseBody = yaml.safeLoad(transaction.real.body);
+
+    transaction.expected.body = yaml.safeDump(requestBody, { "sortKeys": true })
+    transaction.real.body = yaml.safeDump(responseBody, { "sortKeys": true })
+  }
+
+  // Remove the trailing (or well, empty) new line
+  if (transaction.expected.headers['Content-Type'] === 'text/vnd.apiblueprint') {
+    transaction.real.body = transaction.expected.body.replace(/^$/g, '');
+  }
+});

--- a/source/sample.apib
+++ b/source/sample.apib
@@ -1,0 +1,4 @@
+# GET /message
++ Response 200 (text/plain)
+
+        Hello World!

--- a/source/sample.apib
+++ b/source/sample.apib
@@ -1,4 +1,6 @@
-# GET /message
+## /message
+### GET
+
 + Response 200 (text/plain)
 
         Hello World!

--- a/source/sample.apiblueprint.ast-2.0.json
+++ b/source/sample.apiblueprint.ast-2.0.json
@@ -1,0 +1,50 @@
+{
+    "_version": "2.0",
+    "metadata": [],
+    "name": "",
+    "description": "",
+    "resourceGroups": [
+        {
+            "name": "",
+            "description": "",
+            "resources": [
+                {
+                    "name": "",
+                    "description": "",
+                    "uriTemplate": "/message",
+                    "model": {},
+                    "parameters": [],
+                    "actions": [
+                        {
+                            "name": "",
+                            "description": "",
+                            "method": "GET",
+                            "parameters": [],
+                            "examples": [
+                                {
+                                    "name": "",
+                                    "description": "",
+                                    "requests": [],
+                                    "responses": [
+                                        {
+                                            "name": "200",
+                                            "description": "",
+                                            "headers": [
+                                                {
+                                                    "name": "Content-Type",
+                                                    "value": "text/plain"
+                                                }
+                                            ],
+                                            "body": "Hello World!\n",
+                                            "schema": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/source/sample.apiblueprint.ast-2.0.yaml
+++ b/source/sample.apiblueprint.ast-2.0.yaml
@@ -1,0 +1,30 @@
+_version: 2.0
+metadata:
+name:
+description:
+resourceGroups:
+-   name:
+    description:
+    resources:
+    -   name:
+        description:
+        uriTemplate: "/message"
+        model:
+        parameters:
+        actions:
+        -   name:
+            description:
+            method: "GET"
+            parameters:
+            examples:
+            - name:
+                description:
+                requests:
+                responses:
+                -   name: "200"
+                    description:
+                    headers:
+                    -   name: "Content-Type"
+                        value: "text/plain"
+                    body: "Hello World!\n"
+                    schema:

--- a/source/sample.apiblueprint.parse-result.json
+++ b/source/sample.apiblueprint.parse-result.json
@@ -1,0 +1,159 @@
+{
+  "_version": "2.2",
+  "ast": {
+    "_version": "4.0",
+    "metadata": [
+
+    ],
+    "name": "",
+    "description": "",
+    "element": "category",
+    "resourceGroups": [
+      {
+        "name": "",
+        "description": "",
+        "resources": [
+          {
+            "element": "resource",
+            "name": "",
+            "description": "",
+            "uriTemplate": "\/message",
+            "model": {
+
+            },
+            "parameters": [
+
+            ],
+            "actions": [
+              {
+                "name": "",
+                "description": "",
+                "method": "GET",
+                "parameters": [
+
+                ],
+                "attributes": {
+                  "relation": "",
+                  "uriTemplate": ""
+                },
+                "content": [
+
+                ],
+                "examples": [
+                  {
+                    "name": "",
+                    "description": "",
+                    "requests": [
+
+                    ],
+                    "responses": [
+                      {
+                        "name": "200",
+                        "description": "",
+                        "headers": [
+                          {
+                            "name": "Content-Type",
+                            "value": "text\/plain"
+                          }
+                        ],
+                        "body": "Hello World!\n",
+                        "schema": "",
+                        "content": [
+                          {
+                            "element": "asset",
+                            "attributes": {
+                              "role": "bodyExample"
+                            },
+                            "content": "Hello World!\n"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "content": [
+
+            ]
+          }
+        ]
+      }
+    ],
+    "content": [
+      {
+        "element": "category",
+        "content": [
+          {
+            "element": "resource",
+            "name": "",
+            "description": "",
+            "uriTemplate": "\/message",
+            "model": {
+
+            },
+            "parameters": [
+
+            ],
+            "actions": [
+              {
+                "name": "",
+                "description": "",
+                "method": "GET",
+                "parameters": [
+
+                ],
+                "attributes": {
+                  "relation": "",
+                  "uriTemplate": ""
+                },
+                "content": [
+
+                ],
+                "examples": [
+                  {
+                    "name": "",
+                    "description": "",
+                    "requests": [
+
+                    ],
+                    "responses": [
+                      {
+                        "name": "200",
+                        "description": "",
+                        "headers": [
+                          {
+                            "name": "Content-Type",
+                            "value": "text\/plain"
+                          }
+                        ],
+                        "body": "Hello World!\n",
+                        "schema": "",
+                        "content": [
+                          {
+                            "element": "asset",
+                            "attributes": {
+                              "role": "bodyExample"
+                            },
+                            "content": "Hello World!\n"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "content": [
+
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "error": null,
+  "warnings": [
+
+  ]
+}

--- a/source/sample.apiblueprint.parse-result.yaml
+++ b/source/sample.apiblueprint.parse-result.yaml
@@ -1,0 +1,86 @@
+_version: '2.2'
+ast:
+  _version: '4.0'
+  metadata: []
+  name: ''
+  description: ''
+  element: category
+  resourceGroups:
+    - name: ''
+      description: ''
+      resources:
+        - element: resource
+          name: ''
+          description: ''
+          uriTemplate: /message
+          model: {}
+          parameters: []
+          actions:
+            - name: ''
+              description: ''
+              method: GET
+              parameters: []
+              attributes:
+                relation: ''
+                uriTemplate: ''
+              content: []
+              examples:
+                - name: ''
+                  description: ''
+                  requests: []
+                  responses:
+                    - name: '200'
+                      description: ''
+                      headers:
+                        - name: Content-Type
+                          value: text/plain
+                      body: |
+                        Hello World!
+                      schema: ''
+                      content:
+                        - element: asset
+                          attributes:
+                            role: bodyExample
+                          content: |
+                            Hello World!
+          content: []
+  content:
+    - element: category
+      content:
+        - element: resource
+          name: ''
+          description: ''
+          uriTemplate: /message
+          model: {}
+          parameters: []
+          actions:
+            - name: ''
+              description: ''
+              method: GET
+              parameters: []
+              attributes:
+                relation: ''
+                uriTemplate: ''
+              content: []
+              examples:
+                - name: ''
+                  description: ''
+                  requests: []
+                  responses:
+                    - name: '200'
+                      description: ''
+                      headers:
+                        - name: Content-Type
+                          value: text/plain
+                      body: |
+                        Hello World!
+                      schema: ''
+                      content:
+                        - element: asset
+                          attributes:
+                            role: bodyExample
+                          content: |
+                            Hello World!
+          content: []
+error: null
+warnings: []

--- a/source/sample.refract.parse-result.json
+++ b/source/sample.refract.parse-result.json
@@ -1,0 +1,96 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": ""
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": ""
+              },
+              "attributes": {
+                "href": "/message"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": ""
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "200",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "text/plain"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "text/plain"
+                              },
+                              "content": "Hello World!\n"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/sample.refract.parse-result.yaml
+++ b/source/sample.refract.parse-result.yaml
@@ -1,0 +1,54 @@
+element: parseResult
+content:
+  - element: category
+    meta:
+      classes:
+        - api
+      title: ''
+    content:
+      - element: category
+        meta:
+          classes:
+            - resourceGroup
+          title: ''
+        content:
+          - element: resource
+            meta:
+              title: ''
+            attributes:
+              href: /message
+            content:
+              - element: transition
+                meta:
+                  title: ''
+                content:
+                  - element: httpTransaction
+                    content:
+                      - element: httpRequest
+                        attributes:
+                          method: GET
+                        content: []
+                      - element: httpResponse
+                        attributes:
+                          statusCode: '200'
+                          headers:
+                            element: httpHeaders
+                            content:
+                              - element: member
+                                content:
+                                  key:
+                                    element: string
+                                    content: Content-Type
+                                  value:
+                                    element: string
+                                    content: text/plain
+                        content:
+                          - element: asset
+                            meta:
+                              classes:
+                                - messageBody
+                            attributes:
+                              contentType: text/plain
+                            content: |
+                              Hello World!
+error: null


### PR DESCRIPTION
This pull requests adds the initial blueprint for the API Blueprint parsing service adding documentation for Refract parsing.

It uses the hercule tool to transclude the separate JSON/YAML ASTs into the blueprint. It uses the apiary-client to send the blueprint to Apiary on commits to master.

Please review and comment as :+1: to mark this ready for merge, DO NOT merge. I want to merge this myself to check sending it to Apiary works from CircleCI deployment.