### PR TITLE
Update Apiary domain to apiblueprintapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ SOURCES := apiary.apib sample.apib \
 	sample.apiblueprint.ast-2.0.json
 DEPENDENCIES = $(foreach file,$(SOURCES),source/$(file))
 HOST := https://api.apiblueprint.org/
+APIARY_API := apiblueprintapi
 
 apiary.apib: node_modules $(DEPENDENCIES)
 	@echo "Transcluding API Blueprint"
@@ -23,7 +24,7 @@ clean:
 
 publish: apiary.apib
 	@echo "Uploading blueprint to Apiary"
-	@apiary publish --api-name=apiblueprint
+	@apiary publish --api-name=$(APIARY_API)
 
 node_modules:
 	npm install hercule dredd npm js-yaml

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # API Blueprint API
 
-[![Apiary Documentation](https://img.shields.io/badge/Apiary-Documented-blue.svg)](http://docs.apiblueprint.apiary.io/)
+[![Apiary Documentation](https://img.shields.io/badge/Apiary-Documented-blue.svg)](http://docs.apiblueprintapi.apiary.io/)
 
 This repository contains the API Blueprint for the API Blueprint parsing service.
 You can find the documentation for the parsing service on
-[Apiary](http://docs.apiblueprint.apiary.io/).
+[Apiary](http://docs.apiblueprintapi.apiary.io/).
 
 ## Usage
 


### PR DESCRIPTION
Whoops, I set the wrong domain for Apiary, apiblueprint seems to be one that Almad owns and apiblueprintapi is the one we are using.