### PR TITLE
Announce support for AST to be removed end of Feb 2017

### DIFF
--- a/source/composer.apib
+++ b/source/composer.apib
@@ -6,7 +6,10 @@ The composition of API Blueprint is performed as it is provided by the [Matter C
 
 #### Input Media Types
 
-##### API Blueprint AST
+##### API Blueprint AST (Deprecated)
+
+API Blueprint AST support is deprecated and support will be completely removed
+from the service by February 28th 2016.
 
 ```
 application/vnd.apiblueprint.ast+json

--- a/source/parser.apib
+++ b/source/parser.apib
@@ -34,7 +34,10 @@ application/vnd.refract.parse-result+yaml
 
 General-purpose result of the parsing operation. The parse result is in form of the Refract data structure as defined in its [specification](https://github.com/refractproject/refract-spec). The parse result data comply with the [Parse Result Namespace](https://github.com/refractproject/refract-spec/blob/master/namespaces/parse-result-namespace.md).
 
-##### API Blueprint Parse Result
+##### API Blueprint Parse Result (deprecated)
+
+API Blueprint Parse Result support is deprecated and support will be completely
+removed from the service by February 28th 2016.
 
 ```
 application/vnd.apiblueprint.parseresult+json
@@ -42,8 +45,6 @@ application/vnd.apiblueprint.parseresult+yaml
 ```
 
 API Blueprint Parse Result is just serialized API Blueprint AST (`application/vnd.apiblueprint.ast+json` or `application/vnd.apiblueprint.ast+yaml`) alongside with parser annotations (source map, warnings and errors) defined in [Parse Result Media Types](https://github.com/apiaryio/api-blueprint-ast/blob/master/Parse%20Result.md).
-
-Please keep in mind that the API Blueprint parse result media types are soon to be deprecated in favor of the API Description Parse Result Namespace.
 
 + Relation: parse
 
@@ -74,34 +75,6 @@ Please keep in mind that the API Blueprint parse result media types are soon to 
 + Response 200 (application/vnd.refract.parse-result+yaml)
 
         :[](fixtures/apib/normal.refract.parse-result.yaml)
-
-+ Request Parse API Blueprint into JSON Parse Result AST (text/vnd.apiblueprint)
-
-    + Headers
-
-            Accept: application/vnd.apiblueprint.parseresult+json; version=2.2
-
-    + Body
-
-            :[](fixtures/apib/normal.apib)
-
-+ Response 200 (application/vnd.apiblueprint.parseresult+json; version=2.2)
-
-        :[](fixtures/apib/normal.apiblueprint.parseresult.json)
-
-+ Request Parse API Blueprint into YAML Parse Result AST (text/vnd.apiblueprint)
-
-    + Headers
-
-            Accept: application/vnd.apiblueprint.parseresult+yaml; version=2.2
-
-    + Body
-
-            :[](fixtures/apib/normal.apib)
-
-+ Response 200 (application/vnd.apiblueprint.parseresult+yaml; version=2.2)
-
-        :[](fixtures/apib/normal.apiblueprint.parseresult.yaml)
 
 + Request Invalid Document (text/vnd.apiblueprint)
 


### PR DESCRIPTION
I've removed the example http transactions for the parser endpoint that demonstrate API Blueprint AST. I have not for the composer because the composer doesn't support other types at the moment.