### PR TITLE
Prevent CI from running Dredd against parsing service

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
 
 test:
   override:
-    - make test
+    - make apiary.apib
 
 deployment:
   production:


### PR DESCRIPTION
This creates a chicken-egg problem because we cannot update the docs because some changes is not deployed. But we cannot deploy those changes as there are no docs.

I don't believe it makes sense to run dredd against a service here on CI as the repo is decoupled from the code and the version may differ.

Related to https://github.com/apiaryio/api.apiblueprint.org/pull/14