### PR TITLE
Remove empty meta and attributes

### DIFF
--- a/source/fixtures/apiaryb/error.refract.parse-result.json
+++ b/source/fixtures/apiaryb/error.refract.parse-result.json
@@ -1,7 +1,5 @@
 {
   "element": "parseResult",
-  "meta": {},
-  "attributes": {},
   "content": [
     {
       "element": "annotation",
@@ -14,8 +12,6 @@
         "sourceMap": [
           {
             "element": "sourceMap",
-            "meta": {},
-            "attributes": {},
             "content": [
               [
                 31,

--- a/source/fixtures/apiaryb/normal.refract.parse-result.json
+++ b/source/fixtures/apiaryb/normal.refract.parse-result.json
@@ -1,7 +1,5 @@
 {
   "element": "parseResult",
-  "meta": {},
-  "attributes": {},
   "content": [
     {
       "element": "category",
@@ -11,7 +9,6 @@
         ],
         "title": "Sample API"
       },
-      "attributes": {},
       "content": [
         {
           "element": "category",
@@ -21,11 +18,9 @@
               "resourceGroup"
             ]
           },
-          "attributes": {},
           "content": [
             {
               "element": "resource",
-              "meta": {},
               "attributes": {
                 "href": "/message"
               },
@@ -41,12 +36,9 @@
                   "content": [
                     {
                       "element": "httpTransaction",
-                      "meta": {},
-                      "attributes": {},
                       "content": [
                         {
                           "element": "httpRequest",
-                          "meta": {},
                           "attributes": {
                             "method": "GET",
                             "headers": null
@@ -55,29 +47,20 @@
                         },
                         {
                           "element": "httpResponse",
-                          "meta": {},
                           "attributes": {
                             "statusCode": 200,
                             "headers": {
                               "element": "httpHeaders",
-                              "meta": {},
-                              "attributes": {},
                               "content": [
                                 {
                                   "element": "member",
-                                  "meta": {},
-                                  "attributes": {},
                                   "content": {
                                     "key": {
                                       "element": "string",
-                                      "meta": {},
-                                      "attributes": {},
                                       "content": "Content-Type"
                                     },
                                     "value": {
                                       "element": "string",
-                                      "meta": {},
-                                      "attributes": {},
                                       "content": "text/plain"
                                     }
                                   }
@@ -93,7 +76,6 @@
                                   "messageBody"
                                 ]
                               },
-                              "attributes": {},
                               "content": "Hello World!"
                             }
                           ]

--- a/source/fixtures/swagger.json/error.refract.parse-result.json
+++ b/source/fixtures/swagger.json/error.refract.parse-result.json
@@ -1,7 +1,5 @@
 {
   "element": "parseResult",
-  "meta": {},
-  "attributes": {},
   "content": [
     {
       "element": "annotation",
@@ -12,7 +10,6 @@
         "links": [
           {
             "element": "link",
-            "meta": {},
             "attributes": {
               "relation": "origin",
               "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
@@ -26,8 +23,6 @@
         "sourceMap": [
           {
             "element": "sourceMap",
-            "meta": {},
-            "attributes": {},
             "content": [
               [
                 24,

--- a/source/fixtures/swagger.json/normal.refract.parse-result.json
+++ b/source/fixtures/swagger.json/normal.refract.parse-result.json
@@ -1,7 +1,5 @@
 {
   "element": "parseResult",
-  "meta": {},
-  "attributes": {},
   "content": [
     {
       "element": "category",
@@ -11,11 +9,9 @@
         ],
         "title": "Swagger"
       },
-      "attributes": {},
       "content": [
         {
           "element": "resource",
-          "meta": {},
           "attributes": {
             "href": "/test"
           },
@@ -25,22 +21,16 @@
               "meta": {
                 "title": "Test get"
               },
-              "attributes": {},
               "content": [
                 {
                   "element": "copy",
-                  "meta": {},
-                  "attributes": {},
                   "content": "Test description"
                 },
                 {
                   "element": "httpTransaction",
-                  "meta": {},
-                  "attributes": {},
                   "content": [
                     {
                       "element": "httpRequest",
-                      "meta": {},
                       "attributes": {
                         "method": "GET"
                       },
@@ -48,15 +38,12 @@
                     },
                     {
                       "element": "httpResponse",
-                      "meta": {},
                       "attributes": {
                         "statusCode": "204"
                       },
                       "content": [
                         {
                           "element": "copy",
-                          "meta": {},
-                          "attributes": {},
                           "content": "Test response"
                         }
                       ]

--- a/source/fixtures/swagger.json/warning.refract.parse-result.json
+++ b/source/fixtures/swagger.json/warning.refract.parse-result.json
@@ -1,7 +1,5 @@
 {
   "element": "parseResult",
-  "meta": {},
-  "attributes": {},
   "content": [
     {
       "element": "category",
@@ -11,11 +9,9 @@
         ],
         "title": "Swagger"
       },
-      "attributes": {},
       "content": [
         {
           "element": "resource",
-          "meta": {},
           "attributes": {
             "href": "/test"
           },
@@ -25,22 +21,16 @@
               "meta": {
                 "title": "Test get"
               },
-              "attributes": {},
               "content": [
                 {
                   "element": "copy",
-                  "meta": {},
-                  "attributes": {},
                   "content": "Test description"
                 },
                 {
                   "element": "httpTransaction",
-                  "meta": {},
-                  "attributes": {},
                   "content": [
                     {
                       "element": "httpRequest",
-                      "meta": {},
                       "attributes": {
                         "method": "GET"
                       },
@@ -48,8 +38,6 @@
                     },
                     {
                       "element": "httpResponse",
-                      "meta": {},
-                      "attributes": {},
                       "content": []
                     }
                   ]
@@ -69,7 +57,6 @@
         "links": [
           {
             "element": "link",
-            "meta": {},
             "attributes": {
               "relation": "origin",
               "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
@@ -83,8 +70,6 @@
         "sourceMap": [
           {
             "element": "sourceMap",
-            "meta": {},
-            "attributes": {},
             "content": [
               [
                 234,

--- a/source/fixtures/swagger.yaml/error.refract.parse-result.json
+++ b/source/fixtures/swagger.yaml/error.refract.parse-result.json
@@ -1,7 +1,5 @@
 {
   "element": "parseResult",
-  "meta": {},
-  "attributes": {},
   "content": [
     {
       "element": "annotation",
@@ -12,7 +10,6 @@
         "links": [
           {
             "element": "link",
-            "meta": {},
             "attributes": {
               "relation": "origin",
               "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
@@ -26,8 +23,6 @@
         "sourceMap": [
           {
             "element": "sourceMap",
-            "meta": {},
-            "attributes": {},
             "content": [
               [
                 15,

--- a/source/fixtures/swagger.yaml/normal.refract.parse-result.json
+++ b/source/fixtures/swagger.yaml/normal.refract.parse-result.json
@@ -1,7 +1,5 @@
 {
   "element": "parseResult",
-  "meta": {},
-  "attributes": {},
   "content": [
     {
       "element": "category",
@@ -11,11 +9,9 @@
         ],
         "title": "Swagger"
       },
-      "attributes": {},
       "content": [
         {
           "element": "resource",
-          "meta": {},
           "attributes": {
             "href": "/test"
           },
@@ -25,22 +21,16 @@
               "meta": {
                 "title": "Test get"
               },
-              "attributes": {},
               "content": [
                 {
                   "element": "copy",
-                  "meta": {},
-                  "attributes": {},
                   "content": "Test description"
                 },
                 {
                   "element": "httpTransaction",
-                  "meta": {},
-                  "attributes": {},
                   "content": [
                     {
                       "element": "httpRequest",
-                      "meta": {},
                       "attributes": {
                         "method": "GET"
                       },
@@ -48,15 +38,12 @@
                     },
                     {
                       "element": "httpResponse",
-                      "meta": {},
                       "attributes": {
                         "statusCode": "204"
                       },
                       "content": [
                         {
                           "element": "copy",
-                          "meta": {},
-                          "attributes": {},
                           "content": "Test response"
                         }
                       ]

--- a/source/fixtures/swagger.yaml/warning.refract.parse-result.json
+++ b/source/fixtures/swagger.yaml/warning.refract.parse-result.json
@@ -1,7 +1,5 @@
 {
   "element": "parseResult",
-  "meta": {},
-  "attributes": {},
   "content": [
     {
       "element": "category",
@@ -11,11 +9,9 @@
         ],
         "title": "Swagger"
       },
-      "attributes": {},
       "content": [
         {
           "element": "resource",
-          "meta": {},
           "attributes": {
             "href": "/test"
           },
@@ -25,22 +21,16 @@
               "meta": {
                 "title": "Test get"
               },
-              "attributes": {},
               "content": [
                 {
                   "element": "copy",
-                  "meta": {},
-                  "attributes": {},
                   "content": "Test description"
                 },
                 {
                   "element": "httpTransaction",
-                  "meta": {},
-                  "attributes": {},
                   "content": [
                     {
                       "element": "httpRequest",
-                      "meta": {},
                       "attributes": {
                         "method": "GET"
                       },
@@ -48,8 +38,6 @@
                     },
                     {
                       "element": "httpResponse",
-                      "meta": {},
-                      "attributes": {},
                       "content": []
                     }
                   ]
@@ -69,7 +57,6 @@
         "links": [
           {
             "element": "link",
-            "meta": {},
             "attributes": {
               "relation": "origin",
               "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
@@ -83,8 +70,6 @@
         "sourceMap": [
           {
             "element": "sourceMap",
-            "meta": {},
-            "attributes": {},
             "content": [
               [
                 167,


### PR DESCRIPTION
Minim serialiser will no longer include empty meta and attributes and thus they should be removed from API Fixtures.