### PR TITLE
Support 1.0 and 0.6 Refract JSON versions in the /composer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,29 @@
 HERCULE := ./node_modules/.bin/hercule
 DREDD := ./node_modules/.bin/dredd
+
+SOURCE_FIXTURES := \
+	apib/normal apib/warning apib/error \
+	apiaryb/normal apiaryb/error \
+	swagger.json/normal swagger.json/warning swagger.json/error \
+	swagger.yaml/normal swagger.yaml/warning swagger.yaml/error
+
+FIXTURES :=  \
+	$(foreach path,$(SOURCE_FIXTURES),source/fixtures/$(path).refract.parse-result.json) \
+	$(foreach path,$(SOURCE_FIXTURES),source/fixtures/$(path).refract.parse-result.yaml)
+
 SOURCES := apiary.apib introduction.md \
 	root.apib parser.apib composer.apib \
-	fixtures/apib/normal.refract.parse-result.json \
-	fixtures/apib/normal.refract.parse-result.yaml \
 	fixtures/apib/error.apib \
-	fixtures/apib/error.refract.parse-result.yaml \
 	fixtures/swagger.yaml/normal.yaml
-DEPENDENCIES = $(foreach file,$(SOURCES),source/$(file))
+
+DEPENDENCIES = $(foreach file,$(SOURCES),source/$(file)) \
+	$(FIXTURES)
+
 HOST := https://api.apiblueprint.org/
 APIARY_API := apiblueprintapi
+
+FURY_06_JSON = fury -f 'application/vnd.refract.parse-result+json; version=0.6'
+FURY_06_YAML = fury -f 'application/vnd.refract.parse-result+yaml; version=0.6'
 
 apiary.apib: node_modules $(DEPENDENCIES)
 	@echo "Transcluding API Blueprint"
@@ -27,35 +41,44 @@ publish: apiary.apib
 	@apiary publish --api-name=$(APIARY_API)
 
 .PHONY: fixtures
-fixtures:
-	fury source/fixtures/apiaryb/error.apiaryb -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/apiaryb/error.refract.parse-result.json || true
-	fury source/fixtures/apiaryb/error.apiaryb -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/apiaryb/error.refract.parse-result.yaml || true
-	fury source/fixtures/apiaryb/normal.apiaryb -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/apiaryb/normal.refract.parse-result.json
-	fury source/fixtures/apiaryb/normal.apiaryb -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/apiaryb/normal.refract.parse-result.yaml
-	fury source/fixtures/apib/normal.apib -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/apib/normal.refract.parse-result.json
-	fury source/fixtures/apib/normal.apib -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/apib/normal.refract.parse-result.yaml
-	fury source/fixtures/apib/warning.apib -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/apib/warning.refract.parse-result.json
-	fury source/fixtures/apib/warning.apib -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/apib/warning.refract.parse-result.yaml
-	fury source/fixtures/apib/error.apib -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/apib/error.refract.parse-result.json || true
-	fury source/fixtures/apib/error.apib -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/apib/error.refract.parse-result.yaml || true
-	fury source/fixtures/swagger.json/error.json -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/swagger.json/error.refract.parse-result.json || true
-	fury source/fixtures/swagger.json/error.json -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/swagger.json/error.refract.parse-result.yaml || true
-	fury source/fixtures/swagger.json/warning.json -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/swagger.json/warning.refract.parse-result.json
-	fury source/fixtures/swagger.json/warning.json -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/swagger.json/warning.refract.parse-result.yaml
-	fury source/fixtures/swagger.json/normal.json -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/swagger.json/normal.refract.parse-result.json
-	fury source/fixtures/swagger.json/normal.json -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/swagger.json/normal.refract.parse-result.yaml
-	fury source/fixtures/swagger.json/error.json -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/swagger.json/error.refract.parse-result.json || true
-	fury source/fixtures/swagger.json/error.json -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/swagger.json/error.refract.parse-result.yaml || true
-	fury source/fixtures/swagger.json/warning.json -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/swagger.json/warning.refract.parse-result.json
-	fury source/fixtures/swagger.json/warning.json -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/swagger.json/warning.refract.parse-result.yaml
-	fury source/fixtures/swagger.json/normal.json -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/swagger.json/normal.refract.parse-result.json
-	fury source/fixtures/swagger.json/normal.json -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/swagger.json/normal.refract.parse-result.yaml
-	fury source/fixtures/swagger.yaml/error.yaml -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/swagger.yaml/error.refract.parse-result.json || true
-	fury source/fixtures/swagger.yaml/error.yaml -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/swagger.yaml/error.refract.parse-result.yaml || true
-	fury source/fixtures/swagger.yaml/warning.yaml -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/swagger.yaml/warning.refract.parse-result.json
-	fury source/fixtures/swagger.yaml/warning.yaml -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/swagger.yaml/warning.refract.parse-result.yaml
-	fury source/fixtures/swagger.yaml/normal.yaml -f 'application/vnd.refract.parse-result+json; version=0.6' > source/fixtures/swagger.yaml/normal.refract.parse-result.json
-	fury source/fixtures/swagger.yaml/normal.yaml -f 'application/vnd.refract.parse-result+yaml; version=0.6' > source/fixtures/swagger.yaml/normal.refract.parse-result.yaml
+fixtures: $(FIXTURES)
+
+.PHONY: cleanfixtures
+cleanfixtures:
+	@echo "Cleaning Fixtures"
+	@rm $(FIXTURES)
+
+source/fixtures/apib/%.refract.parse-result.json: source/fixtures/apib/%.apib
+	@echo "Generating $@"
+	@$(FURY_06_JSON) $< > $@ || true
+
+source/fixtures/apib/%.refract.parse-result.yaml: source/fixtures/apib/%.apib
+	@echo "Generating $@"
+	@$(FURY_06_YAML) $< > $@ || true
+
+source/fixtures/apiaryb/%.refract.parse-result.json: source/fixtures/apiaryb/%.apiaryb
+	@echo "Generating $@"
+	@$(FURY_06_JSON) $< > $@ || true
+
+source/fixtures/apiaryb/%.refract.parse-result.yaml: source/fixtures/apiaryb/%.apiaryb
+	@echo "Generating $@"
+	@$(FURY_06_YAML) $< > $@ || true
+
+source/fixtures/swagger.json/%.refract.parse-result.json: source/fixtures/swagger.json/%.json
+	@echo "Generating $@"
+	@$(FURY_06_JSON) $< > $@ || true
+
+source/fixtures/swagger.json/%.refract.parse-result.yaml: source/fixtures/swagger.json/%.json
+	@echo "Generating $@"
+	@$(FURY_06_YAML) $< > $@ || true
+
+source/fixtures/swagger.yaml/%.refract.parse-result.json: source/fixtures/swagger.yaml/%.yaml
+	@echo "Generating $@"
+	@$(FURY_06_JSON) $< > $@ || true
+
+source/fixtures/swagger.yaml/%.refract.parse-result.yaml: source/fixtures/swagger.yaml/%.yaml
+	@echo "Generating $@"
+	@$(FURY_06_YAML) $< > $@ || true
 
 node_modules:
 	npm install --no-optional hercule dredd js-yaml media-typer chai fury-cli

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SOURCE_FIXTURES := \
 	swagger.yaml/normal swagger.yaml/warning swagger.yaml/error
 
 FIXTURES :=  \
+	source/fixtures/apib/normal.refract.parse-result.1.0.json \
 	$(foreach path,$(SOURCE_FIXTURES),source/fixtures/$(path).refract.parse-result.json) \
 	$(foreach path,$(SOURCE_FIXTURES),source/fixtures/$(path).refract.parse-result.yaml)
 
@@ -24,6 +25,7 @@ APIARY_API := apiblueprintapi
 
 FURY_06_JSON = fury -f 'application/vnd.refract.parse-result+json; version=0.6'
 FURY_06_YAML = fury -f 'application/vnd.refract.parse-result+yaml; version=0.6'
+FURY_JSON = fury -f 'application/vnd.refract.parse-result+json'
 
 apiary.apib: node_modules $(DEPENDENCIES)
 	@echo "Transcluding API Blueprint"
@@ -51,6 +53,10 @@ cleanfixtures:
 source/fixtures/apib/%.refract.parse-result.json: source/fixtures/apib/%.apib
 	@echo "Generating $@"
 	@$(FURY_06_JSON) $< > $@ || true
+
+source/fixtures/apib/%.refract.parse-result.1.0.json: source/fixtures/apib/%.apib
+	@echo "Generating $@"
+	@$(FURY_JSON) $< > $@ || true
 
 source/fixtures/apib/%.refract.parse-result.yaml: source/fixtures/apib/%.apib
 	@echo "Generating $@"

--- a/source/composer.apib
+++ b/source/composer.apib
@@ -47,6 +47,32 @@ API Blueprint as defined in its [specification](https://github.com/apiaryio/api-
 
         :[](fixtures/apib/composer.apib)
 
++ Request Compose API Blueprint from API Elements 1.0 Parse Result (application/vnd.refract.parse-result+json; version=1.0)
+
+        :[](fixtures/apib/normal.refract.parse-result.1.0.json)
+
++ Response 200 (text/vnd.apiblueprint)
+
+        :[](fixtures/apib/composer.apib)
+
++ Request Compose API Blueprint from API Elements 0.6 Parse Result (application/vnd.refract.parse-result+json; version=0.6)
+
+        :[](fixtures/apib/normal.refract.parse-result.json)
+
++ Response 200 (text/vnd.apiblueprint)
+
+        :[](fixtures/apib/composer.apib)
+
++ Request Unknown Refract Version (application/vnd.refract.parse-result+json; version=2.0)
+
+        {}
+
++ Response 415 (application/vnd.error+json)
+    + Attributes
+        + statusCode: 415 (number)
+        + message: ``Unsupported Refract Serialisation version `2.0`. Supported: 0.6, 1.0.``
+        + name: Rest Error
+
 + Request Unknown Content Type (application/vnd.apiblueprint.ast+json)
 
         {}

--- a/source/fixtures/apib/normal.refract.parse-result.1.0.json
+++ b/source/fixtures/apib/normal.refract.parse-result.1.0.json
@@ -1,0 +1,138 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Hello API"
+        }
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "resourceGroup"
+                }
+              ]
+            },
+            "title": {
+              "element": "string",
+              "content": ""
+            }
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": ""
+                }
+              },
+              "attributes": {
+                "href": {
+                  "element": "string",
+                  "content": "/message"
+                }
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": {
+                      "element": "string",
+                      "content": ""
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": {
+                              "element": "string",
+                              "content": "GET"
+                            }
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": {
+                              "element": "string",
+                              "content": "200"
+                            },
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "text/plain"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "messageBody"
+                                    }
+                                  ]
+                                }
+                              },
+                              "attributes": {
+                                "contentType": {
+                                  "element": "string",
+                                  "content": "text/plain"
+                                }
+                              },
+                              "content": "Hello World!\n"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for Refract 1.0 serialisation to the /composer endpoint. We use version 0.6 by default (for now). This matches current implementation.

I've also included another commit "Break up fixture generation" which achieves the following:

- Allows parallelization
- Makes it simpler to add additional rules
- Fixes correct target dependencies to prevent unnecessary work when files didn't change.