### PR TITLE
Generate all fixtures in Refract 1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ SOURCE_FIXTURES := \
 	swagger.yaml/normal swagger.yaml/warning swagger.yaml/error
 
 FIXTURES :=  \
-	source/fixtures/apib/normal.refract.parse-result.1.0.json \
-	source/fixtures/apib/normal.refract.parse-result.1.0.yaml \
 	$(foreach path,$(SOURCE_FIXTURES),source/fixtures/$(path).refract.parse-result.json) \
-	$(foreach path,$(SOURCE_FIXTURES),source/fixtures/$(path).refract.parse-result.yaml)
+	$(foreach path,$(SOURCE_FIXTURES),source/fixtures/$(path).refract.parse-result.yaml) \
+	$(foreach path,$(SOURCE_FIXTURES),source/fixtures/$(path).refract.parse-result.1.0.json) \
+	$(foreach path,$(SOURCE_FIXTURES),source/fixtures/$(path).refract.parse-result.1.0.yaml)
 
 SOURCES := apiary.apib introduction.md \
 	root.apib parser.apib composer.apib \
@@ -76,6 +76,14 @@ source/fixtures/apiaryb/%.refract.parse-result.yaml: source/fixtures/apiaryb/%.a
 	@echo "Generating $@"
 	@$(FURY_06_YAML) $< > $@ || true
 
+source/fixtures/apiaryb/%.refract.parse-result.1.0.json: source/fixtures/apiaryb/%.apiaryb
+	@echo "Generating $@"
+	@$(FURY_JSON) $< > $@ || true
+
+source/fixtures/apiaryb/%.refract.parse-result.1.0.yaml: source/fixtures/apiaryb/%.apiaryb
+	@echo "Generating $@"
+	@$(FURY_YAML) $< > $@ || true
+
 source/fixtures/swagger.json/%.refract.parse-result.json: source/fixtures/swagger.json/%.json
 	@echo "Generating $@"
 	@$(FURY_06_JSON) $< > $@ || true
@@ -84,6 +92,14 @@ source/fixtures/swagger.json/%.refract.parse-result.yaml: source/fixtures/swagge
 	@echo "Generating $@"
 	@$(FURY_06_YAML) $< > $@ || true
 
+source/fixtures/swagger.json/%.refract.parse-result.1.0.json: source/fixtures/swagger.json/%.json
+	@echo "Generating $@"
+	@$(FURY_JSON) $< > $@ || true
+
+source/fixtures/swagger.json/%.refract.parse-result.1.0.yaml: source/fixtures/swagger.json/%.json
+	@echo "Generating $@"
+	@$(FURY_YAML) $< > $@ || true
+
 source/fixtures/swagger.yaml/%.refract.parse-result.json: source/fixtures/swagger.yaml/%.yaml
 	@echo "Generating $@"
 	@$(FURY_06_JSON) $< > $@ || true
@@ -91,6 +107,14 @@ source/fixtures/swagger.yaml/%.refract.parse-result.json: source/fixtures/swagge
 source/fixtures/swagger.yaml/%.refract.parse-result.yaml: source/fixtures/swagger.yaml/%.yaml
 	@echo "Generating $@"
 	@$(FURY_06_YAML) $< > $@ || true
+
+source/fixtures/swagger.yaml/%.refract.parse-result.1.0.json: source/fixtures/swagger.yaml/%.yaml
+	@echo "Generating $@"
+	@$(FURY_JSON) $< > $@ || true
+
+source/fixtures/swagger.yaml/%.refract.parse-result.1.0.yaml: source/fixtures/swagger.yaml/%.yaml
+	@echo "Generating $@"
+	@$(FURY_YAML) $< > $@ || true
 
 node_modules:
 	npm install --no-optional hercule dredd js-yaml media-typer chai fury-cli

--- a/source/fixtures/apiaryb/error.refract.parse-result.1.0.json
+++ b/source/fixtures/apiaryb/error.refract.parse-result.1.0.json
@@ -1,0 +1,46 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "error"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "content": 31
+                    },
+                    {
+                      "element": "number",
+                      "content": 1
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "Expected \"COPY\", \"DELETE\", \"GET\", \"HEAD\", \"LOCK\", \"MKCOL\", \"MOVE\", \"OPTIONS\", \"PATCH\", \"POST\", \"PROPPATCH\", \"PUT\" or \"UNLOCK\" but end of input found."
+    }
+  ]
+}
+

--- a/source/fixtures/apiaryb/error.refract.parse-result.1.0.yaml
+++ b/source/fixtures/apiaryb/error.refract.parse-result.1.0.yaml
@@ -1,0 +1,27 @@
+element: parseResult
+content:
+  - element: annotation
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: error
+    attributes:
+      sourceMap:
+        element: array
+        content:
+          - element: sourceMap
+            content:
+              - element: array
+                content:
+                  - element: number
+                    content: 31
+                  - element: number
+                    content: 1
+    content: >-
+      Expected "COPY", "DELETE", "GET", "HEAD", "LOCK", "MKCOL", "MOVE",
+      "OPTIONS", "PATCH", "POST", "PROPPATCH", "PUT" or "UNLOCK" but end of
+      input found.
+
+

--- a/source/fixtures/apiaryb/normal.refract.parse-result.1.0.json
+++ b/source/fixtures/apiaryb/normal.refract.parse-result.1.0.json
@@ -1,0 +1,136 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Sample API"
+        }
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "title": {
+              "element": "null",
+              "content": null
+            },
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "resourceGroup"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "resource",
+              "attributes": {
+                "href": {
+                  "element": "string",
+                  "content": "/message"
+                }
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": {
+                      "element": "string",
+                      "content": "GET"
+                    }
+                  },
+                  "attributes": {
+                    "href": {
+                      "element": "string",
+                      "content": "/message"
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": {
+                              "element": "string",
+                              "content": "GET"
+                            },
+                            "headers": {
+                              "element": "null",
+                              "content": null
+                            }
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": {
+                              "element": "number",
+                              "content": 200
+                            },
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "text/plain"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "messageBody"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": "Hello World!"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/fixtures/apiaryb/normal.refract.parse-result.1.0.yaml
+++ b/source/fixtures/apiaryb/normal.refract.parse-result.1.0.yaml
@@ -1,0 +1,77 @@
+element: parseResult
+content:
+  - element: category
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: api
+      title:
+        element: string
+        content: Sample API
+    content:
+      - element: category
+        meta:
+          title:
+            element: 'null'
+            content: null
+          classes:
+            element: array
+            content:
+              - element: string
+                content: resourceGroup
+        content:
+          - element: resource
+            attributes:
+              href:
+                element: string
+                content: /message
+            content:
+              - element: transition
+                meta:
+                  title:
+                    element: string
+                    content: GET
+                attributes:
+                  href:
+                    element: string
+                    content: /message
+                content:
+                  - element: httpTransaction
+                    content:
+                      - element: httpRequest
+                        attributes:
+                          method:
+                            element: string
+                            content: GET
+                          headers:
+                            element: 'null'
+                            content: null
+                        content: []
+                      - element: httpResponse
+                        attributes:
+                          statusCode:
+                            element: number
+                            content: 200
+                          headers:
+                            element: httpHeaders
+                            content:
+                              - element: member
+                                content:
+                                  key:
+                                    element: string
+                                    content: Content-Type
+                                  value:
+                                    element: string
+                                    content: text/plain
+                        content:
+                          - element: asset
+                            meta:
+                              classes:
+                                element: array
+                                content:
+                                  - element: string
+                                    content: messageBody
+                            content: Hello World!
+

--- a/source/fixtures/apib/error.refract.parse-result.1.0.json
+++ b/source/fixtures/apib/error.refract.parse-result.1.0.json
@@ -1,0 +1,50 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "error"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 4
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "content": 39
+                    },
+                    {
+                      "element": "number",
+                      "content": 9
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "base type 'A' circularly referencing itself"
+    }
+  ]
+}
+

--- a/source/fixtures/apib/error.refract.parse-result.1.0.yaml
+++ b/source/fixtures/apib/error.refract.parse-result.1.0.yaml
@@ -1,0 +1,27 @@
+element: parseResult
+content:
+  - element: annotation
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: error
+    attributes:
+      code:
+        element: number
+        content: 4
+      sourceMap:
+        element: array
+        content:
+          - element: sourceMap
+            content:
+              - element: array
+                content:
+                  - element: number
+                    content: 39
+                  - element: number
+                    content: 9
+    content: base type 'A' circularly referencing itself
+
+

--- a/source/fixtures/apib/warning.refract.parse-result.1.0.json
+++ b/source/fixtures/apib/warning.refract.parse-result.1.0.json
@@ -1,0 +1,143 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Hello"
+        }
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "resourceGroup"
+                }
+              ]
+            },
+            "title": {
+              "element": "string",
+              "content": ""
+            }
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": ""
+                }
+              },
+              "attributes": {
+                "href": {
+                  "element": "string",
+                  "content": "/"
+                }
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": {
+                      "element": "string",
+                      "content": ""
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": {
+                              "element": "string",
+                              "content": "GET"
+                            }
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": {
+                              "element": "string",
+                              "content": "204"
+                            }
+                          },
+                          "content": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 3
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "content": 18
+                    },
+                    {
+                      "element": "number",
+                      "content": 14
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "no parameters specified, expected a nested list of parameters, one parameter per list item"
+    }
+  ]
+}
+

--- a/source/fixtures/apib/warning.refract.parse-result.1.0.yaml
+++ b/source/fixtures/apib/warning.refract.parse-result.1.0.yaml
@@ -1,0 +1,81 @@
+element: parseResult
+content:
+  - element: category
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: api
+      title:
+        element: string
+        content: Hello
+    content:
+      - element: category
+        meta:
+          classes:
+            element: array
+            content:
+              - element: string
+                content: resourceGroup
+          title:
+            element: string
+            content: ''
+        content:
+          - element: resource
+            meta:
+              title:
+                element: string
+                content: ''
+            attributes:
+              href:
+                element: string
+                content: /
+            content:
+              - element: transition
+                meta:
+                  title:
+                    element: string
+                    content: ''
+                content:
+                  - element: httpTransaction
+                    content:
+                      - element: httpRequest
+                        attributes:
+                          method:
+                            element: string
+                            content: GET
+                        content: []
+                      - element: httpResponse
+                        attributes:
+                          statusCode:
+                            element: string
+                            content: '204'
+                        content: []
+  - element: annotation
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: warning
+    attributes:
+      code:
+        element: number
+        content: 3
+      sourceMap:
+        element: array
+        content:
+          - element: sourceMap
+            content:
+              - element: array
+                content:
+                  - element: number
+                    content: 18
+                  - element: number
+                    content: 14
+    content: >-
+      no parameters specified, expected a nested list of parameters, one
+      parameter per list item
+
+

--- a/source/fixtures/swagger.json/error.refract.parse-result.1.0.json
+++ b/source/fixtures/swagger.json/error.refract.parse-result.1.0.json
@@ -1,0 +1,69 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "error"
+            }
+          ]
+        },
+        "links": {
+          "element": "array",
+          "content": [
+            {
+              "element": "link",
+              "attributes": {
+                "relation": {
+                  "element": "string",
+                  "content": "origin"
+                },
+                "href": {
+                  "element": "string",
+                  "content": "http://docs.apiary.io/validations/swagger#swagger-validation"
+                }
+              },
+              "content": []
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 4
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "content": 24
+                    },
+                    {
+                      "element": "number",
+                      "content": 37
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "Missing required property: version"
+    }
+  ]
+}
+

--- a/source/fixtures/swagger.json/error.refract.parse-result.1.0.yaml
+++ b/source/fixtures/swagger.json/error.refract.parse-result.1.0.yaml
@@ -1,0 +1,39 @@
+element: parseResult
+content:
+  - element: annotation
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: error
+      links:
+        element: array
+        content:
+          - element: link
+            attributes:
+              relation:
+                element: string
+                content: origin
+              href:
+                element: string
+                content: 'http://docs.apiary.io/validations/swagger#swagger-validation'
+            content: []
+    attributes:
+      code:
+        element: number
+        content: 4
+      sourceMap:
+        element: array
+        content:
+          - element: sourceMap
+            content:
+              - element: array
+                content:
+                  - element: number
+                    content: 24
+                  - element: number
+                    content: 37
+    content: 'Missing required property: version'
+
+

--- a/source/fixtures/swagger.json/normal.refract.parse-result.1.0.json
+++ b/source/fixtures/swagger.json/normal.refract.parse-result.1.0.json
@@ -1,0 +1,81 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Swagger"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/test"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "Test get"
+                }
+              },
+              "content": [
+                {
+                  "element": "copy",
+                  "content": "Test description"
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "204"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "Test response"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/fixtures/swagger.json/normal.refract.parse-result.1.0.yaml
+++ b/source/fixtures/swagger.json/normal.refract.parse-result.1.0.yaml
@@ -1,0 +1,44 @@
+element: parseResult
+content:
+  - element: category
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: api
+      title:
+        element: string
+        content: Swagger
+    content:
+      - element: resource
+        attributes:
+          href:
+            element: string
+            content: /test
+        content:
+          - element: transition
+            meta:
+              title:
+                element: string
+                content: Test get
+            content:
+              - element: copy
+                content: Test description
+              - element: httpTransaction
+                content:
+                  - element: httpRequest
+                    attributes:
+                      method:
+                        element: string
+                        content: GET
+                    content: []
+                  - element: httpResponse
+                    attributes:
+                      statusCode:
+                        element: string
+                        content: '204'
+                    content:
+                      - element: copy
+                        content: Test response
+

--- a/source/fixtures/swagger.json/warning.refract.parse-result.1.0.json
+++ b/source/fixtures/swagger.json/warning.refract.parse-result.1.0.json
@@ -1,0 +1,134 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Swagger"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/test"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "Test get"
+                }
+              },
+              "content": [
+                {
+                  "element": "copy",
+                  "content": "Test description"
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "content": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        },
+        "links": {
+          "element": "array",
+          "content": [
+            {
+              "element": "link",
+              "attributes": {
+                "relation": {
+                  "element": "string",
+                  "content": "origin"
+                },
+                "href": {
+                  "element": "string",
+                  "content": "http://docs.apiary.io/validations/swagger#refract-not-supported"
+                }
+              },
+              "content": []
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 3
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "content": 234
+                    },
+                    {
+                      "element": "number",
+                      "content": 67
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "Default response is not yet supported"
+    }
+  ]
+}
+

--- a/source/fixtures/swagger.json/warning.refract.parse-result.1.0.yaml
+++ b/source/fixtures/swagger.json/warning.refract.parse-result.1.0.yaml
@@ -1,0 +1,75 @@
+element: parseResult
+content:
+  - element: category
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: api
+      title:
+        element: string
+        content: Swagger
+    content:
+      - element: resource
+        attributes:
+          href:
+            element: string
+            content: /test
+        content:
+          - element: transition
+            meta:
+              title:
+                element: string
+                content: Test get
+            content:
+              - element: copy
+                content: Test description
+              - element: httpTransaction
+                content:
+                  - element: httpRequest
+                    attributes:
+                      method:
+                        element: string
+                        content: GET
+                    content: []
+                  - element: httpResponse
+                    content: []
+  - element: annotation
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: warning
+      links:
+        element: array
+        content:
+          - element: link
+            attributes:
+              relation:
+                element: string
+                content: origin
+              href:
+                element: string
+                content: >-
+                  http://docs.apiary.io/validations/swagger#refract-not-supported
+            content: []
+    attributes:
+      code:
+        element: number
+        content: 3
+      sourceMap:
+        element: array
+        content:
+          - element: sourceMap
+            content:
+              - element: array
+                content:
+                  - element: number
+                    content: 234
+                  - element: number
+                    content: 67
+    content: Default response is not yet supported
+
+

--- a/source/fixtures/swagger.yaml/error.refract.parse-result.1.0.json
+++ b/source/fixtures/swagger.yaml/error.refract.parse-result.1.0.json
@@ -1,0 +1,69 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "error"
+            }
+          ]
+        },
+        "links": {
+          "element": "array",
+          "content": [
+            {
+              "element": "link",
+              "attributes": {
+                "relation": {
+                  "element": "string",
+                  "content": "origin"
+                },
+                "href": {
+                  "element": "string",
+                  "content": "http://docs.apiary.io/validations/swagger#swagger-validation"
+                }
+              },
+              "content": []
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 4
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "content": 15
+                    },
+                    {
+                      "element": "number",
+                      "content": 23
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "Missing required property: version"
+    }
+  ]
+}
+

--- a/source/fixtures/swagger.yaml/error.refract.parse-result.1.0.yaml
+++ b/source/fixtures/swagger.yaml/error.refract.parse-result.1.0.yaml
@@ -1,0 +1,39 @@
+element: parseResult
+content:
+  - element: annotation
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: error
+      links:
+        element: array
+        content:
+          - element: link
+            attributes:
+              relation:
+                element: string
+                content: origin
+              href:
+                element: string
+                content: 'http://docs.apiary.io/validations/swagger#swagger-validation'
+            content: []
+    attributes:
+      code:
+        element: number
+        content: 4
+      sourceMap:
+        element: array
+        content:
+          - element: sourceMap
+            content:
+              - element: array
+                content:
+                  - element: number
+                    content: 15
+                  - element: number
+                    content: 23
+    content: 'Missing required property: version'
+
+

--- a/source/fixtures/swagger.yaml/normal.refract.parse-result.1.0.json
+++ b/source/fixtures/swagger.yaml/normal.refract.parse-result.1.0.json
@@ -1,0 +1,81 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Swagger"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/test"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "Test get"
+                }
+              },
+              "content": [
+                {
+                  "element": "copy",
+                  "content": "Test description"
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "204"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "Test response"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/fixtures/swagger.yaml/normal.refract.parse-result.1.0.yaml
+++ b/source/fixtures/swagger.yaml/normal.refract.parse-result.1.0.yaml
@@ -1,0 +1,44 @@
+element: parseResult
+content:
+  - element: category
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: api
+      title:
+        element: string
+        content: Swagger
+    content:
+      - element: resource
+        attributes:
+          href:
+            element: string
+            content: /test
+        content:
+          - element: transition
+            meta:
+              title:
+                element: string
+                content: Test get
+            content:
+              - element: copy
+                content: Test description
+              - element: httpTransaction
+                content:
+                  - element: httpRequest
+                    attributes:
+                      method:
+                        element: string
+                        content: GET
+                    content: []
+                  - element: httpResponse
+                    attributes:
+                      statusCode:
+                        element: string
+                        content: '204'
+                    content:
+                      - element: copy
+                        content: Test response
+

--- a/source/fixtures/swagger.yaml/warning.refract.parse-result.1.0.json
+++ b/source/fixtures/swagger.yaml/warning.refract.parse-result.1.0.json
@@ -1,0 +1,134 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Swagger"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/test"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "Test get"
+                }
+              },
+              "content": [
+                {
+                  "element": "copy",
+                  "content": "Test description"
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "content": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        },
+        "links": {
+          "element": "array",
+          "content": [
+            {
+              "element": "link",
+              "attributes": {
+                "relation": {
+                  "element": "string",
+                  "content": "origin"
+                },
+                "href": {
+                  "element": "string",
+                  "content": "http://docs.apiary.io/validations/swagger#refract-not-supported"
+                }
+              },
+              "content": []
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 3
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "content": 167
+                    },
+                    {
+                      "element": "number",
+                      "content": 46
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "Default response is not yet supported"
+    }
+  ]
+}
+

--- a/source/fixtures/swagger.yaml/warning.refract.parse-result.1.0.yaml
+++ b/source/fixtures/swagger.yaml/warning.refract.parse-result.1.0.yaml
@@ -1,0 +1,75 @@
+element: parseResult
+content:
+  - element: category
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: api
+      title:
+        element: string
+        content: Swagger
+    content:
+      - element: resource
+        attributes:
+          href:
+            element: string
+            content: /test
+        content:
+          - element: transition
+            meta:
+              title:
+                element: string
+                content: Test get
+            content:
+              - element: copy
+                content: Test description
+              - element: httpTransaction
+                content:
+                  - element: httpRequest
+                    attributes:
+                      method:
+                        element: string
+                        content: GET
+                    content: []
+                  - element: httpResponse
+                    content: []
+  - element: annotation
+    meta:
+      classes:
+        element: array
+        content:
+          - element: string
+            content: warning
+      links:
+        element: array
+        content:
+          - element: link
+            attributes:
+              relation:
+                element: string
+                content: origin
+              href:
+                element: string
+                content: >-
+                  http://docs.apiary.io/validations/swagger#refract-not-supported
+            content: []
+    attributes:
+      code:
+        element: number
+        content: 3
+      sourceMap:
+        element: array
+        content:
+          - element: sourceMap
+            content:
+              - element: array
+                content:
+                  - element: number
+                    content: 167
+                  - element: number
+                    content: 46
+    content: Default response is not yet supported
+
+


### PR DESCRIPTION
This PR targets #28 generating all of the fixtures. #28 only updates the fixtures used by the core API Blueprint file.