### PR TITLE
Use Content-Type to demonstate invalid input type

### DIFF
--- a/source/parser.apib
+++ b/source/parser.apib
@@ -138,7 +138,7 @@ General-purpose result of the parsing operation. The parse result is in form of 
 
     + Headers
 
-            Accept: application/raml+yaml
+            Content-Type: application/raml+yaml
 
     + Body
 


### PR DESCRIPTION
The Accept Header is for the requested output type, not input type therefore it doesn't match what this request/response example is trying to demonstrate.

> + Request Unsupported Input Media Type