### PR TITLE
Update composer fixture to remove empty group

### DIFF
--- a/source/fixtures/apib/composer.apib
+++ b/source/fixtures/apib/composer.apib
@@ -2,8 +2,6 @@ FORMAT: 1A
 
 # Hello API
 
-## Group 
-
 ### /message
 
 #### GET


### PR DESCRIPTION
Creation of empty groups was fixed in fury-adapter-apib-serializer@0.8.0. This fixture update is to allow release in our parsing service which tests against this fixture.